### PR TITLE
Update image paths in markdown file

### DIFF
--- a/images/PARTS_GALLERY.md
+++ b/images/PARTS_GALLERY.md
@@ -6,56 +6,56 @@ An up-to-date visual list of all parts added by this KSP2 mod.
 
 ### GRN-250 / Medium Cylindrical Greenhouse (M)
 
-![Medium cylindrical greenhouse part](../KLSSUnity/Assets/KLSS_greenhouse_2v_long_icon.png)
+![Medium cylindrical greenhouse part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_greenhouse_2v_long_icon.png)
 
 ### CPST-150 / Medium Inline Composter (M)
 
-![medium inline composter part](../KLSSUnity/Assets/KLSS_composter_2v_short_icon.png)
+![medium inline composter part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_composter_2v_short_icon.png)
 
 ## Combined Storage
 
 ### SCS-100 / Small Combined Storage (S)
 
-![small combined storage part](../KLSSUnity/Assets/KLSS_life_support_tank_1v_1x1_icon.png)
+![small combined storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_life_support_tank_1v_1x1_icon.png)
 
 ### MCS-100 / Medium Combined Storage (M)
 
-![small combined storage part](../KLSSUnity/Assets/KLSS_life_support_tank_2v_1x1_icon.png)
+![small combined storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_life_support_tank_2v_1x1_icon.png)
 
 ## Individual Storage
 
 ### PFS-10 / Portable Food Storage (XS)
 
-![portable food storage part](../KLSSUnity/Assets/KLSS_food_pack_0v_radial_icon.png)
+![portable food storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_food_pack_0v_radial_icon.png)
 
 ### PWS-10 / Portable Water Storage (XS)
 
-![portable water storage part](../KLSSUnity/Assets/KLSS_water_tank_0v_radial_icon.png)
+![portable water storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_water_tank_0v_radial_icon.png)
 
 ### POS-10 / Portable Oxygen Storage (XS)
 
-![portable oxygen storage part](../KLSSUnity/Assets/KLSS_oxygen_tank_0v_radial_icon.png)
+![portable oxygen storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_oxygen_tank_0v_radial_icon.png)
 
 ### MFS-200 / Medium Food Storage (M)
 
-![medium food storage part](../KLSSUnity/Assets/KLSS_food_tank_2v_1x2_icon.png)
+![medium food storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_food_tank_2v_1x2_icon.png)
 
 ### MWS-200 / Medium Water Storage (M)
 
-![medium water storage part](../KLSSUnity/Assets/KLSS_water_tank_2v_1x2_icon.png)
+![medium water storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_water_tank_2v_1x2_icon.png)
 
 ### MOS-200 / Medium Oxygen Storage (M)
 
-![medium oxygen storage part](../KLSSUnity/Assets/KLSS_oxygen_tank_2v_1x2_icon.png)
+![medium oxygen storage part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_oxygen_tank_2v_1x2_icon.png)
 
 ### TFC-300 / Triangular Food Container (M)
 
-![triangular food container part](../KLSSUnity/Assets/KLSS_food_pack_2v_radial_icon.png)
+![triangular food container part](../KerbalLifeSupportSystem.Unity|g/Assets/KLSS_food_pack_2v_radial_icon.png)
 
 ### TWC-300 / Triangular Water Container (M)
 
-![triangular water container part](../KLSSUnity/Assets/KLSS_water_tank_2v_radial_icon.png)
+![triangular water container part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_water_tank_2v_radial_icon.png)
 
 ### TOC-300 / Triangular Oxygen Container (M)
 
-![triangular oxygen container part](../KLSSUnity/Assets/KLSS_oxygen_tank_2v_radial_icon.png)
+![triangular oxygen container part](../src/KerbalLifeSupportSystem.Unity/Assets/KLSS_oxygen_tank_2v_radial_icon.png)


### PR DESCRIPTION
After the recent project restructuring in commit 059d493: Redo Unity project, the image paths in images/PARTS_GALLERY.md were pointing to the wrong location. This commit corrects all image paths, ensuring they now reflect the updated project structure. Images should now display correctly in the document.